### PR TITLE
Update ROFL parser

### DIFF
--- a/Rofl.Extract.Data/Models/ROFL.cs
+++ b/Rofl.Extract.Data/Models/ROFL.cs
@@ -28,32 +28,47 @@ public class ROFL
     /// <summary>
     /// The 6 bytes all ROFL files begin with
     /// </summary>
-    public static readonly byte[] Signature = { 0x52, 0x49, 0x4F, 0x54, 0x00, 0x00 };
+
+    // The signature of a ROFL file is always this bytes array then the game version and 22 bytes that look like random the same between all files
+    public static readonly byte[] Signature = { 0x52, 0x49, 0x4F, 0x54, 0x02, 0x00, 0x75, 0x1C, 0x08, 0xCD, 0x20, 0x99, 0xF8, 0x1C, 0x0E };
 
     ///
+
+    // I let the original code commented if someone find the location of offsets but for me there is no more offsets in the new replay files
+    // public ROFL()
+    // {
+    //     LoadState = LoadState.Empty;
+    //     ChunkHeaders = new List<ChunkHeader>();
+    //     Chunks = new List<Chunk>();
+    // }
+
+    // public ROFL(LoadState loadState,
+    //             byte[]? replaySignature,
+    //             Lengths? lengths,
+    //             Metadata? metadata,
+    //             PayloadHeader? payloadHeader,
+    //             IEnumerable<ChunkHeader> chunkHeaders,
+    //             IEnumerable<Chunk> chunks)
+    // {
+    //     LoadState = loadState;
+    //     ReplaySignature = replaySignature;
+    //     Lengths = lengths;
+    //     Metadata = metadata;
+    //     PayloadHeader = payloadHeader;
+    //     ChunkHeaders = chunkHeaders;
+    //     Chunks = chunks;
+    // }
 
     public ROFL()
     {
         LoadState = LoadState.Empty;
-        ChunkHeaders = new List<ChunkHeader>();
-        Chunks = new List<Chunk>();
     }
 
-    public ROFL(LoadState loadState,
-                byte[]? replaySignature,
-                Lengths? lengths,
-                Metadata? metadata,
-                PayloadHeader? payloadHeader,
-                IEnumerable<ChunkHeader> chunkHeaders,
-                IEnumerable<Chunk> chunks)
+    public ROFL(LoadState loadState, String gameVersion, Metadata? metadata)
     {
         LoadState = loadState;
-        ReplaySignature = replaySignature;
-        Lengths = lengths;
+        GameVersion = gameVersion;
         Metadata = metadata;
-        PayloadHeader = payloadHeader;
-        ChunkHeaders = chunkHeaders;
-        Chunks = chunks;
     }
 
     /// <summary>
@@ -68,18 +83,21 @@ public class ROFL
             throw new Exception("cannot save file unless it has been fully loaded");
         }
 
-        var chunkHeaderBytes = ChunkHeaders.Select(x => x.ToBytes())
-            .Aggregate((a, b) => { return a.Concat(b).ToArray(); });
+        return new byte[0]; // Temporary return value for SampleApp to compile
 
-        var chunkBytes = Chunks.Select(x => x.ToBytes())
-            .Aggregate((a, b) => { return a.Concat(b).ToArray(); });
+        // I let the original code commented if someone find the location of offsets but for me there is no more offsets in the new replay files
+        // var chunkHeaderBytes = ChunkHeaders.Select(x => x.ToBytes())
+        //     .Aggregate((a, b) => { return a.Concat(b).ToArray(); });
 
-        var bytesToWrite = Signature.Concat(ReplaySignature!)
-            .Concat(Lengths!.ToBytes()).Concat(Metadata!.ToBytes())
-            .Concat(PayloadHeader!.ToBytes()).Concat(chunkHeaderBytes)
-            .Concat(chunkBytes).ToArray();
+        // var chunkBytes = Chunks.Select(x => x.ToBytes())
+        //     .Aggregate((a, b) => { return a.Concat(b).ToArray(); });
 
-        return bytesToWrite;
+        // var bytesToWrite = Signature.Concat(ReplaySignature!)
+        //     .Concat(Lengths!.ToBytes()).Concat(Metadata!.ToBytes())
+        //     .Concat(PayloadHeader!.ToBytes()).Concat(chunkHeaderBytes)
+        //     .Concat(chunkBytes).ToArray();
+
+        // return bytesToWrite;
     }
 
     // Class Properties
@@ -87,16 +105,20 @@ public class ROFL
     public LoadState LoadState { get; private set; }
 
     // ROFL file contents
-
-    public byte[]? ReplaySignature { get; private set; }
-
-    public Lengths? Lengths { get; private set; }
+    public String GameVersion { get; private set; }
 
     public Metadata? Metadata { get; private set; }
 
-    public PayloadHeader? PayloadHeader { get; private set; }
+    // I let the original code commented if someone find the location of offsets but for me there is no more offsets in the new replay files
+    // public byte[]? ReplaySignature { get; private set; }
 
-    public IEnumerable<ChunkHeader> ChunkHeaders { get; private set; }
+    // public Lengths? Lengths { get; private set; }
 
-    public IEnumerable<Chunk> Chunks { get; private set; }
+    // public Metadata? Metadata { get; private set; }
+
+    // public PayloadHeader? PayloadHeader { get; private set; }
+
+    // public IEnumerable<ChunkHeader> ChunkHeaders { get; private set; }
+
+    // public IEnumerable<Chunk> Chunks { get; private set; }
 }

--- a/Rofl.Extract.Data/Models/Rofl/Metadata.cs
+++ b/Rofl.Extract.Data/Models/Rofl/Metadata.cs
@@ -31,7 +31,6 @@ public class Metadata
             ?? throw new Exception("RawMetadata parsed to null");
 
         GameLength = rawMetadata.GameLength;
-        GameVersion = rawMetadata.GameVersion!;
         LastGameChunkId = rawMetadata.LastGameChunkId;
         LastKeyframeId = rawMetadata.LastKeyframeId;
 
@@ -48,7 +47,6 @@ public class Metadata
         var rawMetadata = new RawMetadata
         {
             GameLength = GameLength,
-            GameVersion = GameVersion,
             LastGameChunkId = LastGameChunkId,
             LastKeyframeId = LastKeyframeId,
             StatsJson = playerStatsJson
@@ -66,11 +64,6 @@ public class Metadata
     /// Duration of the game, in milliseconds
     /// </summary>
     public ulong GameLength { get; private set; }
-
-    /// <summary>
-    /// Patch version the game occurred on
-    /// </summary>
-    public string GameVersion { get; private set; }
 
     /// <summary>
     /// Chunk ID of the last chunk
@@ -92,9 +85,6 @@ public class RawMetadata
 {
     [JsonPropertyName("gameLength")]
     public ulong GameLength { get; set; }
-
-    [JsonPropertyName("gameVersion")]
-    public string? GameVersion { get; set; }
 
     [JsonPropertyName("lastGameChunkId")]
     public uint LastGameChunkId { get; set; }

--- a/Rofl.Extract.Data/Models/Rofl/PlayerStats.cs
+++ b/Rofl.Extract.Data/Models/Rofl/PlayerStats.cs
@@ -221,6 +221,27 @@ public class PlayerStats
     [JsonPropertyName("MUTED_ALL")]
     public string? MutedAll { get; set; }
 
+    [JsonPropertyName("Missions_ChampionsKilled")]
+    public string? MissionsChampionsKilled { get; set; }
+
+    [JsonPropertyName("Missions_CreepScore")]
+    public string? MissionsCreepScore { get; set; }
+
+    [JsonPropertyName("Missions_GoldFromStructuresDestroyed")]
+    public string? MissionsGoldFromStructuresDestroyed { get; set; }
+
+    [JsonPropertyName("Missions_GoldFromTurretPlatesTaken")]
+    public string? MissionsGoldFromTurretPlatesTaken { get; set; }
+
+    [JsonPropertyName("Missions_HealingFromLevelObjects")]
+    public string? MissionsHealingFromLevelObjects { get; set; }
+
+    [JsonPropertyName("Missions_MinionsKilled")]
+    public string? MissionsMinionsKilled { get; set; }
+
+    [JsonPropertyName("Missions_TurretPlatesDestroyed")]
+    public string? MissionsTurretPlatesDestroyed { get; set; }
+
     [JsonPropertyName("NAME")]
     public string? Name { get; set; }
 

--- a/Rofl.Extract.Data/RoflReader.cs
+++ b/Rofl.Extract.Data/RoflReader.cs
@@ -4,6 +4,7 @@ using Fraxiinus.Rofl.Extract.Data.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -39,78 +40,115 @@ public static class RoflReader
             throw new ArgumentException("cannot read from stream", nameof(stream));
         }
 
-        // read header, it is a known size of 288
-        // in order to increase performance, do BIG READS instead of small ones
-        byte[] headerBytes = await stream.ReadBytesAsync(288, cancellationToken);
+        // The new replay files seem to have the same header of size 48 bytes
+        stream.Position = 15; // At the 15th byte is the 14 byte version of the game
+        byte[] buffer = new byte[14]; // The game version is 14 bytes long
+        await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+        string gameVersion = Encoding.UTF8.GetString(buffer);
 
-        if (!CheckFileSignature(headerBytes))
+        LoadState loadState = LoadState.Empty;
+        byte[] pattern = new byte[] { 0x7B, 0x22, 0x67, 0x61, 0x6D, 0x65, 0x4C, 0x65, 0x6E, 0x67, 0x74, 0x68, 0x22 };
+        Metadata metadata;
+
+        using (MemoryStream ms = new MemoryStream(1000))
         {
-            throw new Exception("file signature does not match ROFL format");
-        }
+            await stream.CopyToAsync(ms, cancellationToken);
+            byte[] content = ms.ToArray();
+            int position = IndexOf(content, pattern);
 
-        // replay signature is always 256 bytes
-        var replaySignature = headerBytes[6..262];
-        // lengths fields are always 26 bytes
-        var lengths = new Lengths(headerBytes[262..]);
-
-        // what to read next depends on user
-        int bytesLeft = (int)(lengths.File - lengths.Header); // read everything
-        if (!loadAll)
-        {
-            bytesLeft = (int)(lengths.Metadata + lengths.PayloadHeader); // read just metadata and payload header
-        }
-
-        // ohhhh big read
-        byte[] fileContentBytes = await stream.ReadBytesAsync(bytesLeft, cancellationToken);
-
-        var metadata = new Metadata(fileContentBytes[0..(int)lengths.Metadata]);
-
-        int payloadHeaderEnd = (int)(lengths.Metadata + lengths.PayloadHeader);
-        var payloadHeader = new PayloadHeader(fileContentBytes[(int)lengths.Metadata..payloadHeaderEnd]);
-        var chunkHeaders = new List<ChunkHeader>();
-        var chunks = new List<Chunk>();
-        LoadState loadState;
-
-        if (loadAll)
-        {
-            var chunkHeaderResults = new List<ChunkHeader>();
-            int chunkHeaderStart = 0;
-            for (int i = 0; i < payloadHeader.ChunkCount + payloadHeader.KeyframeCount; i++)
+            if (position != -1)
             {
-                // chunk headers are exactly 17 bytes
-                chunkHeaderStart = payloadHeaderEnd + (17 * i);
-                byte[] chunkHeaderBytes = fileContentBytes[chunkHeaderStart..(chunkHeaderStart + 17)];
-                chunkHeaderResults.Add(new ChunkHeader(chunkHeaderBytes));
+                byte[] newContent = content[position..^4];
+                metadata = new(newContent);
             }
-            chunkHeaders = chunkHeaderResults;
-
-            var chunkResults = new List<Chunk>();
-            int chunkOffset = chunkHeaderStart + 17; // count last chunk header
-            for (int i = 0; i < chunkHeaders.Count; i++)
+            else
             {
-                var chunkHeader = chunkHeaderResults[i];
-                byte[] chunkBytes = fileContentBytes[chunkOffset..(int)(chunkOffset + chunkHeader.ChunkLength)];
-                chunkResults.Add(new Chunk(chunkHeader.ChunkId, chunkHeader.ChunkType, chunkBytes));
-
-                // chunk lengths are not uniform, add at the end
-                chunkOffset += (int)chunkHeader.ChunkLength;
+                throw new Exception("Pattern not found");
             }
-            chunks = chunkResults;
-
-            loadState = LoadState.Full;
-        }
-        else
-        {
-            loadState = LoadState.NoPayload;
         }
 
-        return new ROFL(loadState,
-                        replaySignature,
-                        lengths,
-                        metadata,
-                        payloadHeader,
-                        chunkHeaders,
-                        chunks);
+        loadState = LoadState.Full;
+
+        return new ROFL(loadState, gameVersion, metadata);
+
+        // I let the original code commented if someone find the location of offsets but for me there is no more offsets in the new replay files
+        // if (!stream.CanRead)
+        // {
+        //     throw new ArgumentException("cannot read from stream", nameof(stream));
+        // }
+
+        // // read header, it is a known size of 288
+        // // in order to increase performance, do BIG READS instead of small ones
+        // byte[] headerBytes = await stream.ReadBytesAsync(288, cancellationToken);
+
+        // if (!CheckFileSignature(headerBytes))
+        // {
+        //     throw new Exception("file signature does not match ROFL format");
+        // }
+
+        // // replay signature is always 256 bytes
+        // var replaySignature = headerBytes[6..262];
+        // // lengths fields are always 26 bytes
+        // var lengths = new Lengths(headerBytes[262..]);
+
+        // // what to read next depends on user
+        // int bytesLeft = (int)(lengths.File - lengths.Header); // read everything
+        // if (!loadAll)
+        // {
+        //     bytesLeft = (int)(lengths.Metadata + lengths.PayloadHeader); // read just metadata and payload header
+        // }
+
+        // // ohhhh big read
+        // byte[] fileContentBytes = await stream.ReadBytesAsync(bytesLeft, cancellationToken);
+
+        // var metadata = new Metadata(fileContentBytes[0..(int)lengths.Metadata]);
+
+        // int payloadHeaderEnd = (int)(lengths.Metadata + lengths.PayloadHeader);
+        // var payloadHeader = new PayloadHeader(fileContentBytes[(int)lengths.Metadata..payloadHeaderEnd]);
+        // var chunkHeaders = new List<ChunkHeader>();
+        // var chunks = new List<Chunk>();
+        // LoadState loadState;
+
+        // if (loadAll)
+        // {
+        //     var chunkHeaderResults = new List<ChunkHeader>();
+        //     int chunkHeaderStart = 0;
+        //     for (int i = 0; i < payloadHeader.ChunkCount + payloadHeader.KeyframeCount; i++)
+        //     {
+        //         // chunk headers are exactly 17 bytes
+        //         chunkHeaderStart = payloadHeaderEnd + (17 * i);
+        //         byte[] chunkHeaderBytes = fileContentBytes[chunkHeaderStart..(chunkHeaderStart + 17)];
+        //         chunkHeaderResults.Add(new ChunkHeader(chunkHeaderBytes));
+        //     }
+        //     chunkHeaders = chunkHeaderResults;
+
+        //     var chunkResults = new List<Chunk>();
+        //     int chunkOffset = chunkHeaderStart + 17; // count last chunk header
+        //     for (int i = 0; i < chunkHeaders.Count; i++)
+        //     {
+        //         var chunkHeader = chunkHeaderResults[i];
+        //         byte[] chunkBytes = fileContentBytes[chunkOffset..(int)(chunkOffset + chunkHeader.ChunkLength)];
+        //         chunkResults.Add(new Chunk(chunkHeader.ChunkId, chunkHeader.ChunkType, chunkBytes));
+
+        //         // chunk lengths are not uniform, add at the end
+        //         chunkOffset += (int)chunkHeader.ChunkLength;
+        //     }
+        //     chunks = chunkResults;
+
+        //     loadState = LoadState.Full;
+        // }
+        // else
+        // {
+        //     loadState = LoadState.NoPayload;
+        // }
+
+        // return new ROFL(loadState,
+        //                 replaySignature,
+        //                 lengths,
+        //                 metadata,
+        //                 payloadHeader,
+        //                 chunkHeaders,
+        //                 chunks);
     }
 
     private static bool CheckFileSignature(byte[] headerBytes)
@@ -123,6 +161,26 @@ public static class RoflReader
             }
         }
         return true;
+    }
+
+    private static int IndexOf(byte[] haystack, byte[] needle)
+    {
+        for (int i = 0; i <= haystack.Length - needle.Length; i++)
+        {
+            bool found = true;
+            for (int j = 0; j < needle.Length; j++)
+            {
+                if (haystack[i + j] != needle[j])
+                {
+                    found = false;
+                    break;
+                }
+            }
+
+            if (found) return i;
+        }
+
+        return -1;
     }
 }
 


### PR DESCRIPTION
# New replay file format
## Changes
- The signature of the files has been changed
    - 4 first bytes => RIOT
    - 11 bytes which appear to be the same for all replay files (EUW)
    - 14 bytes => game version 
    - 22 bytes which appear to be the same for all replay files (EUW)
- Offsets
I found no trace of the old offsets, I tried to read as before in increments of 26 bytes starting from each cursor location
- Stats
    - There is 7 new stats
        - ```json
          "Missions_ChampionsKilled": "6",
          "Missions_CreepScore": "162",
          "Missions_GoldFromStructuresDestroyed": "450",
          "Missions_GoldFromTurretPlatesTaken": "0",
          "Missions_HealingFromLevelObjects": "0",
          "Missions_MinionsKilled": "156",
          "Missions_TurretPlatesDestroyed": "0"
           ```
    - The stats always seem to be at the end of the replays except the last 4 bytes

## Not changed
- All files always start with "RIOT"

I left the old code in comments if anyone finds the offsets
To find the locations of the stats without the offsets I base myself on the pattern at the start of the stats (13 bytes)
There doesn't seem to be any time difference between the old method and the current one.

I'm a CS student so my code is probably not perfect ^^"